### PR TITLE
InstallFonts.ps1: Add ability to install fonts per-user without admin rights. 

### DIFF
--- a/InstallFonts.ps1
+++ b/InstallFonts.ps1
@@ -62,10 +62,12 @@ function Install-Font {
 				If ( -not (($winMajorVersion -ge 10) -and ($winBuild -ge 17044))) {
 					throw "At least Windows 10 Build 17044 is required for local user installation. You have Win $winMajorVersion Build $winBuild."
 				}
-				$fontTarget = $env:localappdata + "\Microsoft\Windows\Fonts\" + $FontFile.Name
+				$fontTarget = $env:localappdata + "\Microsoft\Windows\Fonts\" 
 				$regPath = "HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Fonts"
-				$regValue = $fontTarget
+				$regValue = $fontTarget + $FontFile.Name
 				$regName = $FontName
+				# The Fonts directory does not always exist on a per user level. Create it.
+				New-Item -ItemType Directory -Force -Path "$fontTarget"
 		}
 
 		$CopyFailed = $true
@@ -112,5 +114,5 @@ function Install-Font {
 foreach ($FontItem in (Get-ChildItem -Path $PSScriptRoot | Where-Object {
 			($_.Name -like '*.ttf') -or ($_.Name -like '*.OTF')
 		})) {
-	Install-Font -FontFile $FontItem $true
+	Install-Font -FontFile $FontItem $false
 }


### PR DESCRIPTION
This PR only modifiies InstallFonts.ps1. There are 2 basic changes:

- add the ability to install fonts without admin rights for the current user only. Requires win 10 build  17044 which we check for.
- Somewhat restructure/try to improve the code but try to keep the same basic structure which you used in your branch.

Please note I unfortunately somewhat messed up my git commits, so there are less small commits and only two or three larger commits. Sorry about that. 